### PR TITLE
"Remove 'default' keyword from Scheduler class export"

### DIFF
--- a/typing/index.d.ts
+++ b/typing/index.d.ts
@@ -1,7 +1,7 @@
 import { ConfigType, Dayjs, OptionType } from 'dayjs';
 import React, { CSSProperties } from 'react';
 
-export default class Scheduler<EventType extends EventItem = EventItem> extends React.Component<SchedulerProps<EventType>, any> {}
+export class Scheduler<EventType extends EventItem = EventItem> extends React.Component<SchedulerProps<EventType>, any> {}
 
 export const AddMorePopover: <EventType extends EventItem = EventItem>(props: AddMorePopoverProps<EventType>) => React.ReactElement;
 


### PR DESCRIPTION
Fix the Import of Scheduler Class in Typescript.