### PR TITLE
patch(fix): Fix parent-based scheduler resizing behavior

### DIFF
--- a/src/components/ResourceEvents.jsx
+++ b/src/components/ResourceEvents.jsx
@@ -188,8 +188,8 @@ class ResourceEvents extends PureComponent {
         rightIndex,
         width,
         isSelecting: true,
-        startRowIndex: 0,
-        endRowIndex: 0,
+        startRowIndex: -1,
+        endRowIndex: -1,
       });
       this.emitSelectionChange(true, [], { left, width });
       return;

--- a/src/components/ResourceEvents.jsx
+++ b/src/components/ResourceEvents.jsx
@@ -8,6 +8,8 @@ import EventItem from './EventItem';
 import SelectedArea from './SelectedArea';
 import Summary from './Summary';
 
+const DEFAULT_ROW_HEIGHT = 50;
+
 class ResourceEvents extends PureComponent {
   static propTypes = {
     resourceEvents: PropTypes.object.isRequired,
@@ -30,7 +32,11 @@ class ResourceEvents extends PureComponent {
     eventItemTemplateResolver: PropTypes.func,
     onSelectionChange: PropTypes.func,
     isRowSelected: PropTypes.bool,
-    selectionPreview: PropTypes.object,
+    selectionPreview: PropTypes.shape({
+      isSelecting: PropTypes.bool,
+      left: PropTypes.number,
+      width: PropTypes.number,
+    }),
   };
 
   constructor(props) {
@@ -73,7 +79,7 @@ class ResourceEvents extends PureComponent {
   componentWillUnmount() {
     this.cleanupDragInteraction();
     this.supportTouchHelper('remove');
-    this.emitSelectionChange(false, []);
+    this.emitSelectionChange(false, [], { left: 0, width: 0 });
   }
 
   cleanupDragInteraction = () => {
@@ -175,7 +181,21 @@ class ResourceEvents extends PureComponent {
     }
     const currentY = clientY - pos.y;
     const displayRenderData = this.getDisplayRenderData();
-    const rowHeights = displayRenderData.map(row => row?.rowHeight || 50);
+    if (displayRenderData.length === 0) {
+      this.setState({
+        leftIndex,
+        left,
+        rightIndex,
+        width,
+        isSelecting: true,
+        startRowIndex: 0,
+        endRowIndex: 0,
+      });
+      this.emitSelectionChange(true, [], { left, width });
+      return;
+    }
+
+    const rowHeights = displayRenderData.map(row => row?.rowHeight || DEFAULT_ROW_HEIGHT);
     const startRowTop = rowHeights.slice(0, Math.max(0, originalStartRowIndex)).reduce((sum, h) => sum + h, 0);
     const absoluteY = startRowTop + currentY;
 

--- a/src/components/ResourceView.jsx
+++ b/src/components/ResourceView.jsx
@@ -156,7 +156,7 @@ function ResourceView({
 
   return (
     <div style={{ paddingBottom }}>
-      <table className="resource-table">
+      <table className="resource-table" role="grid" aria-multiselectable="true">
         <tbody>{resourceList}</tbody>
       </table>
     </div>

--- a/src/components/ResourceView.jsx
+++ b/src/components/ResourceView.jsx
@@ -63,8 +63,11 @@ function ResourceView({
     const selectedBorderColor = schedulerData.config.selectedSlotBorderColor || '#1677ff';
     const selectedShadowColor = schedulerData.config.selectedSlotShadowColor || '#91caff';
     const selectedSlotColor = schedulerData.config.selectedSlotColor || '#e6f4ff';
-    const isRowSelected =
-      isSelecting && Array.isArray(selectedResourceIds) && selectedResourceIds.includes(item.slotId);
+    const hasSelectedResourceId =
+      selectedResourceIds instanceof Set
+        ? selectedResourceIds.has(item.slotId)
+        : Array.isArray(selectedResourceIds) && selectedResourceIds.includes(item.slotId);
+    const isRowSelected = isSelecting && hasSelectedResourceId;
     if (isRowSelected) {
       tdStyle.borderLeft = `3px solid ${selectedBorderColor}`;
       tdStyle.boxShadow = `inset 0 0 0 1px ${selectedShadowColor}`;
@@ -75,7 +78,7 @@ function ResourceView({
 
     if (CustomResourceCell) {
       return (
-        <tr key={item.slotId}>
+        <tr key={item.slotId} aria-selected={isRowSelected}>
           <td data-resource-id={item.slotId} style={tdStyle}>
             <CustomResourceCell
               schedulerData={schedulerData}
@@ -134,7 +137,7 @@ function ResourceView({
     }
 
     return (
-      <tr key={item.slotId}>
+      <tr key={item.slotId} aria-selected={isRowSelected}>
         <td data-resource-id={item.slotId} style={tdStyle}>
           {slotItem}
         </td>
@@ -169,7 +172,10 @@ ResourceView.propTypes = {
   toggleExpandFunc: PropTypes.func,
   CustomResourceCell: PropTypes.func,
   isSelecting: PropTypes.bool,
-  selectedResourceIds: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  selectedResourceIds: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+    PropTypes.instanceOf(Set),
+  ]),
 };
 
 export default React.memo(ResourceView);

--- a/src/components/SchedulerData.js
+++ b/src/components/SchedulerData.js
@@ -87,10 +87,11 @@ export default class SchedulerData {
     if (this._batchCount > 0) {
       this._batchCount -= 1;
       if (this._batchCount === 0 && this._pendingVersion !== undefined) {
-        if (typeof this._versionChangeCallback === 'function') {
-          this._versionChangeCallback(this._pendingVersion);
-        }
+        const pendingVersion = this._pendingVersion;
         this._pendingVersion = undefined;
+        if (typeof this._versionChangeCallback === 'function') {
+          this._versionChangeCallback(pendingVersion);
+        }
       }
     }
   }
@@ -260,9 +261,7 @@ export default class SchedulerData {
     const isCustomView = viewType === ViewType.Custom || viewType === ViewType.Custom1 || viewType === ViewType.Custom2;
 
     // Force built-in views only; custom views can provide their own cellUnit via custom date behavior.
-    if (viewType === ViewType.Day) {
-      this.cellUnit = CellUnit.Hour;
-    } else if (!isCustomView) {
+    if (!isCustomView && viewType !== ViewType.Day) {
       this.cellUnit = CellUnit.Day;
     }
 

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -133,17 +133,7 @@ function Scheduler(props) {
   });
   const [, setRenderTrigger] = useState(0);
 
-  // Callback ref pattern for ResizeObserver to handle parent element reassignment
-  const [parentEl, setParentEl] = useState(null);
-  const setParentRef = useCallback(
-    el => {
-      if (parentRef) {
-        parentRef.current = el;
-      }
-      setParentEl(el);
-    },
-    [parentRef]
-  );
+  const schedulerRootRef = useRef(null);
 
   // Layout/header refs - declare before setSchedulerHeaderRef useCallback
   const schedulerHeaderRef = useRef(null);
@@ -203,20 +193,21 @@ function Scheduler(props) {
   }, [schedulerData, parentRef, onWindowResize]);
 
   useEffect(() => {
+    const parentEl = parentRef?.current;
     if (parentRef !== undefined && schedulerData.config.responsiveByParent && !!parentEl) {
-      schedulerData._setDocumentWidth(parentEl.offsetWidth);
+      const updateParentSize = () => {
+        schedulerData._setDocumentWidth(parentEl.clientWidth);
+        schedulerData._setDocumentHeight(parentEl.clientHeight);
+      };
+
+      updateParentSize();
 
       // Disconnect any previous observer to prevent memory leaks
       if (ulObserverRef.current) {
         ulObserverRef.current.disconnect();
       }
 
-      ulObserverRef.current = new ResizeObserver(() => {
-        if (parentEl) {
-          schedulerData._setDocumentWidth(parentEl.offsetWidth);
-          schedulerData._setDocumentHeight(parentEl.offsetHeight);
-        }
-      });
+      ulObserverRef.current = new ResizeObserver(updateParentSize);
 
       ulObserverRef.current.observe(parentEl);
 
@@ -226,21 +217,21 @@ function Scheduler(props) {
         }
       };
     }
-  }, [parentEl, parentRef, schedulerData]);
+  }, [parentRef, schedulerData]);
 
   useEffect(() => {
     if (schedulerData.config.responsiveByParent && !!schedulerHeaderEl) {
-      schedulerData._setDocumentWidth(schedulerHeaderEl.offsetWidth);
-      schedulerData._setDocumentHeight(schedulerHeaderEl.offsetHeight);
+      const updateHeaderHeight = node => {
+        const rect = node.getBoundingClientRect();
+        const style = window.getComputedStyle(node);
+        const totalHeight = rect.height + (parseFloat(style.marginTop) || 0) + (parseFloat(style.marginBottom) || 0);
+        schedulerData._setSchedulerHeaderHeight(totalHeight);
+      };
+
+      updateHeaderHeight(schedulerHeaderEl);
 
       headerObserverRef.current = new ResizeObserver(entries => {
-        entries.forEach(entry => {
-          const node = entry.target;
-          const rect = node.getBoundingClientRect();
-          const style = window.getComputedStyle(node);
-          const totalHeight = rect.height + (parseFloat(style.marginTop) || 0) + (parseFloat(style.marginBottom) || 0);
-          schedulerData._setSchedulerHeaderHeight(totalHeight);
-        });
+        entries.forEach(entry => updateHeaderHeight(entry.target));
       });
 
       headerObserverRef.current.observe(schedulerHeaderEl);
@@ -748,7 +739,7 @@ function Scheduler(props) {
   const rootTableStyle = useMemo(() => ({ width: `${width}px` }), [width]);
 
   return (
-    <table id="rbs-root" className="rbs" style={rootTableStyle} ref={setParentRef}>
+    <table id="rbs-root" className="rbs" style={rootTableStyle} ref={schedulerRootRef}>
       <thead>
         <tr>
           <td colSpan="2">{schedulerHeader}</td>

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -237,8 +237,8 @@ function Scheduler(props) {
       headerObserverRef.current.observe(schedulerHeaderEl);
 
       return () => {
-        if (headerObserverRef.current && schedulerHeaderEl) {
-          headerObserverRef.current.unobserve(schedulerHeaderEl);
+        if (headerObserverRef.current) {
+          headerObserverRef.current.disconnect();
         }
       };
     }

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -176,8 +176,13 @@ function Scheduler(props) {
   }, [schedulerData]);
 
   const onWindowResize = useCallback(() => {
-    schedulerData._setDocumentWidth(document.documentElement.clientWidth);
-    schedulerData._setDocumentHeight(document.documentElement.clientHeight);
+    schedulerData.beginBatch();
+    try {
+      schedulerData._setDocumentWidth(document.documentElement.clientWidth);
+      schedulerData._setDocumentHeight(document.documentElement.clientHeight);
+    } finally {
+      schedulerData.endBatch();
+    }
   }, [schedulerData]);
 
   useEffect(() => {
@@ -185,8 +190,13 @@ function Scheduler(props) {
       (schedulerData.isSchedulerResponsive() && !schedulerData.config.responsiveByParent) ||
       parentRef === undefined
     ) {
-      schedulerData._setDocumentWidth(document.documentElement.clientWidth);
-      schedulerData._setDocumentHeight(document.documentElement.clientHeight);
+      schedulerData.beginBatch();
+      try {
+        schedulerData._setDocumentWidth(document.documentElement.clientWidth);
+        schedulerData._setDocumentHeight(document.documentElement.clientHeight);
+      } finally {
+        schedulerData.endBatch();
+      }
       window.addEventListener('resize', onWindowResize);
       return () => window.removeEventListener('resize', onWindowResize);
     }
@@ -196,8 +206,13 @@ function Scheduler(props) {
     const parentEl = parentRef?.current;
     if (parentRef !== undefined && schedulerData.config.responsiveByParent && !!parentEl) {
       const updateParentSize = () => {
-        schedulerData._setDocumentWidth(parentEl.clientWidth);
-        schedulerData._setDocumentHeight(parentEl.clientHeight);
+        schedulerData.beginBatch();
+        try {
+          schedulerData._setDocumentWidth(parentEl.clientWidth);
+          schedulerData._setDocumentHeight(parentEl.clientHeight);
+        } finally {
+          schedulerData.endBatch();
+        }
       };
 
       updateParentSize();
@@ -224,7 +239,11 @@ function Scheduler(props) {
       const updateHeaderHeight = node => {
         const rect = node.getBoundingClientRect();
         const style = window.getComputedStyle(node);
-        const totalHeight = rect.height + (parseFloat(style.marginTop) || 0) + (parseFloat(style.marginBottom) || 0);
+        const totalHeight =
+          rect.height +
+          (parseFloat(style.marginTop) || 0) +
+          (parseFloat(style.marginBottom) || 0) +
+          (schedulerData.config.showWeekNumber ? schedulerData.config.weekNumberRowHeight || 0 : 0);
         schedulerData._setSchedulerHeaderHeight(totalHeight);
       };
 

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -261,7 +261,7 @@ function Scheduler(props) {
         }
       };
     }
-  }, [schedulerHeaderEl, schedulerData]);
+  }, [schedulerHeaderEl, schedulerData, schedulerData.config.showWeekNumber, schedulerData.config.weekNumberRowHeight]);
 
   const resolveScrollbarSize = useCallback(() => {
     const prev = scrollbarSizeRef.current;

--- a/src/examples/pages/Add-More/class-based.jsx
+++ b/src/examples/pages/Add-More/class-based.jsx
@@ -124,10 +124,7 @@ class AddMore extends Component {
           `start: ${start}, end: ${end}, type: ${type}, item: ${item}}`
       )
     ) {
-      let newFreshId = 0;
-      schedulerData.events.forEach(existingEvent => {
-        if (existingEvent.id >= newFreshId) newFreshId = existingEvent.id + 1;
-      });
+      const newFreshId = Math.max(0, ...schedulerData.events.map(existingEvent => existingEvent.id)) + 1;
       const selectedResourceIds =
         Array.isArray(item?.resourceIds) && item.resourceIds.length > 0 ? item.resourceIds : [slotId];
 

--- a/src/examples/pages/Add-More/class-based.jsx
+++ b/src/examples/pages/Add-More/class-based.jsx
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import { AddMorePopover, DemoData, Scheduler, SchedulerData, ViewType, wrapperFun } from '../../../index';
+import { getNextNumericEventId } from '../../../helper/utility';
 
 class AddMore extends Component {
   constructor(props) {
@@ -123,11 +124,7 @@ class AddMore extends Component {
         `Do you want to create a new event? {slotId: ${slotId}, slotName: ${slotName}, ` +
           `start: ${start}, end: ${end}, type: ${type}, item: ${item}}`
       )
-    ) {
-      const numericIds = schedulerData.events
-        .map(existingEvent => existingEvent.id)
-        .filter(id => typeof id === 'number' && Number.isFinite(id));
-      const newFreshId = Math.max(...numericIds, 0) + 1;
+    ) {      const newFreshId = getNextNumericEventId(schedulerData.events);
       const selectedResourceIds =
         Array.isArray(item?.resourceIds) && item.resourceIds.length > 0 ? item.resourceIds : [slotId];
 

--- a/src/examples/pages/Add-More/class-based.jsx
+++ b/src/examples/pages/Add-More/class-based.jsx
@@ -124,7 +124,10 @@ class AddMore extends Component {
           `start: ${start}, end: ${end}, type: ${type}, item: ${item}}`
       )
     ) {
-      const newFreshId = Math.max(0, ...schedulerData.events.map(existingEvent => existingEvent.id)) + 1;
+      const numericIds = schedulerData.events
+        .map(existingEvent => existingEvent.id)
+        .filter(id => typeof id === 'number' && Number.isFinite(id));
+      const newFreshId = Math.max(...numericIds, 0) + 1;
       const selectedResourceIds =
         Array.isArray(item?.resourceIds) && item.resourceIds.length > 0 ? item.resourceIds : [slotId];
 

--- a/src/examples/pages/Add-More/class-based.jsx
+++ b/src/examples/pages/Add-More/class-based.jsx
@@ -124,7 +124,8 @@ class AddMore extends Component {
         `Do you want to create a new event? {slotId: ${slotId}, slotName: ${slotName}, ` +
           `start: ${start}, end: ${end}, type: ${type}, item: ${item}}`
       )
-    ) {      const newFreshId = getNextNumericEventId(schedulerData.events);
+    ) {
+      const newFreshId = getNextNumericEventId(schedulerData.events);
       const selectedResourceIds =
         Array.isArray(item?.resourceIds) && item.resourceIds.length > 0 ? item.resourceIds : [slotId];
 

--- a/src/examples/pages/Basic/class-based.jsx
+++ b/src/examples/pages/Basic/class-based.jsx
@@ -108,10 +108,7 @@ class Basic extends Component {
           `start: ${start}, end: ${end}, type: ${type}, item: ${item}}`
       )
     ) {
-      let newFreshId = 0;
-      schedulerData.events.forEach(existingEvent => {
-        if (existingEvent.id >= newFreshId) newFreshId = existingEvent.id + 1;
-      });
+      const newFreshId = Math.max(0, ...schedulerData.events.map(existingEvent => existingEvent.id)) + 1;
       const selectedResourceIds =
         Array.isArray(item?.resourceIds) && item.resourceIds.length > 0 ? item.resourceIds : [slotId];
 

--- a/src/examples/pages/Basic/class-based.jsx
+++ b/src/examples/pages/Basic/class-based.jsx
@@ -3,6 +3,7 @@ import * as dayjsLocale from 'dayjs/locale/pt-br';
 import { Component } from 'react';
 
 import { DemoData, Scheduler, SchedulerData, ViewType, wrapperFun } from '../../../index';
+import { getNextNumericEventId } from '../../../helper/utility';
 
 class Basic extends Component {
   constructor(props) {
@@ -107,11 +108,7 @@ class Basic extends Component {
         `Do you want to create a new event? {slotId: ${slotId}, slotName: ${slotName}, ` +
           `start: ${start}, end: ${end}, type: ${type}, item: ${item}}`
       )
-    ) {
-      const numericIds = schedulerData.events
-        .map(existingEvent => existingEvent.id)
-        .filter(id => typeof id === 'number' && Number.isFinite(id));
-      const newFreshId = Math.max(...numericIds, 0) + 1;
+    ) {      const newFreshId = getNextNumericEventId(schedulerData.events);
       const selectedResourceIds =
         Array.isArray(item?.resourceIds) && item.resourceIds.length > 0 ? item.resourceIds : [slotId];
 

--- a/src/examples/pages/Basic/class-based.jsx
+++ b/src/examples/pages/Basic/class-based.jsx
@@ -108,7 +108,10 @@ class Basic extends Component {
           `start: ${start}, end: ${end}, type: ${type}, item: ${item}}`
       )
     ) {
-      const newFreshId = Math.max(0, ...schedulerData.events.map(existingEvent => existingEvent.id)) + 1;
+      const numericIds = schedulerData.events
+        .map(existingEvent => existingEvent.id)
+        .filter(id => typeof id === 'number' && Number.isFinite(id));
+      const newFreshId = Math.max(...numericIds, 0) + 1;
       const selectedResourceIds =
         Array.isArray(item?.resourceIds) && item.resourceIds.length > 0 ? item.resourceIds : [slotId];
 

--- a/src/examples/pages/Basic/class-based.jsx
+++ b/src/examples/pages/Basic/class-based.jsx
@@ -108,7 +108,8 @@ class Basic extends Component {
         `Do you want to create a new event? {slotId: ${slotId}, slotName: ${slotName}, ` +
           `start: ${start}, end: ${end}, type: ${type}, item: ${item}}`
       )
-    ) {      const newFreshId = getNextNumericEventId(schedulerData.events);
+    ) {
+      const newFreshId = getNextNumericEventId(schedulerData.events);
       const selectedResourceIds =
         Array.isArray(item?.resourceIds) && item.resourceIds.length > 0 ? item.resourceIds : [slotId];
 

--- a/src/examples/pages/Custom-Time/class-based.jsx
+++ b/src/examples/pages/Custom-Time/class-based.jsx
@@ -109,8 +109,8 @@ class CustomTime extends Component {
       )
     ) {
       let newFreshId = 0;
-      schedulerData.events.forEach(item => {
-        if (item.id >= newFreshId) newFreshId = item.id + 1;
+      schedulerData.events.forEach(existingEvent => {
+        if (existingEvent.id >= newFreshId) newFreshId = existingEvent.id + 1;
       });
       const selectedResourceIds =
         Array.isArray(item?.resourceIds) && item.resourceIds.length > 0 ? item.resourceIds : [slotId];

--- a/src/examples/pages/Custom-Time/class-based.jsx
+++ b/src/examples/pages/Custom-Time/class-based.jsx
@@ -108,7 +108,8 @@ class CustomTime extends Component {
         `Do you want to create a new event? {slotId: ${slotId}, slotName: ${slotName}, ` +
           `start: ${start}, end: ${end}, type: ${type}, item: ${item}}`
       )
-    ) {      const newFreshId = getNextNumericEventId(schedulerData.events);
+    ) {
+      const newFreshId = getNextNumericEventId(schedulerData.events);
       const selectedResourceIds =
         Array.isArray(item?.resourceIds) && item.resourceIds.length > 0 ? item.resourceIds : [slotId];
 

--- a/src/examples/pages/Custom-Time/class-based.jsx
+++ b/src/examples/pages/Custom-Time/class-based.jsx
@@ -3,6 +3,7 @@ import * as dayjsLocale from 'dayjs/locale/pt-br';
 import { Component } from 'react';
 
 import { DemoData, Scheduler, SchedulerData, ViewType, wrapperFun } from '../../../index';
+import { getNextNumericEventId } from '../../../helper/utility';
 
 class CustomTime extends Component {
   constructor(props) {
@@ -107,11 +108,7 @@ class CustomTime extends Component {
         `Do you want to create a new event? {slotId: ${slotId}, slotName: ${slotName}, ` +
           `start: ${start}, end: ${end}, type: ${type}, item: ${item}}`
       )
-    ) {
-      let newFreshId = 0;
-      schedulerData.events.forEach(existingEvent => {
-        if (existingEvent.id >= newFreshId) newFreshId = existingEvent.id + 1;
-      });
+    ) {      const newFreshId = getNextNumericEventId(schedulerData.events);
       const selectedResourceIds =
         Array.isArray(item?.resourceIds) && item.resourceIds.length > 0 ? item.resourceIds : [slotId];
 

--- a/src/helper/utility.js
+++ b/src/helper/utility.js
@@ -11,3 +11,16 @@ export function getPos(element) {
 
   return { x, y };
 }
+
+/**
+ * Generates the next numeric event ID by finding the maximum numeric ID in the events array
+ * and incrementing it by 1. Filters out non-numeric and non-finite IDs.
+ * @param {Array} events - Array of event objects with id properties
+ * @returns {number} The next available numeric ID
+ */
+export function getNextNumericEventId(events) {
+  const numericIds = events
+    .map(event => event.id)
+    .filter(id => typeof id === 'number' && Number.isFinite(id));
+  return Math.max(...numericIds, 0) + 1;
+}

--- a/src/helper/utility.js
+++ b/src/helper/utility.js
@@ -19,8 +19,6 @@ export function getPos(element) {
  * @returns {number} The next available numeric ID
  */
 export function getNextNumericEventId(events) {
-  const numericIds = events
-    .map(event => event.id)
-    .filter(id => typeof id === 'number' && Number.isFinite(id));
+  const numericIds = events.map(event => event.id).filter(id => typeof id === 'number' && Number.isFinite(id));
   return Math.max(...numericIds, 0) + 1;
 }


### PR DESCRIPTION
Fixes parent-based responsive sizing so the scheduler measures the provided parent container instead of replacing that ref with its own root table.

Changes:
- Preserve the external `parentRef` contract.
- Observe the parent container with `ResizeObserver`.
- Update scheduler width and height from the parent’s client dimensions.
- Keep header height tracking separate from document height updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added ARIA attributes to the resource table and per-row aria-selected for better screen reader support.

* **Bug Fixes**
  * Selection tracking now behaves correctly when display data is unavailable.
  * Selection preview is reliably cleared on unmount.

* **Improvements**
  * Consistent default row height for more accurate vertical selection.
  * More robust responsive layout and header-height measurement.
  * Streamlined generation of new event IDs and more reliable row selection state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->