### PR TITLE
Add date normalization utilities and improve Month view rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ See the demo `events` in the [sample1.js](https://github.com/ansulagrawal/react-
 If we use the task view, we'd better add the `groupId` and the `groupName` property to each event object, see the
 `eventsForTaskView` in the [sample1.js](https://github.com/ansulagrawal/react-big-schedule/blob/master/src/sample-data/sample1.js) for details.
 
+## Event Date Formats
+
+Events support both `YYYY-MM-DD HH:mm:ss` datetime strings and `YYYY-MM-DD` date-only strings for `start` and `end`.
+Date-only events are treated as spanning the full calendar day. Month view and the other scheduler views handle both
+formats consistently.
+
 #### prev
 
 ```js

--- a/src/components/ResourceEvents.jsx
+++ b/src/components/ResourceEvents.jsx
@@ -2,7 +2,7 @@ import { PropTypes } from 'prop-types';
 import React, { PureComponent } from 'react';
 import { useDrop } from 'react-dnd';
 import { CellUnit, DATETIME_FORMAT, DnDTypes, SummaryPos } from '../config/default';
-import { getPos } from '../helper/utility';
+import { getPos, normalizeEventEnd, normalizeEventStart } from '../helper/utility';
 import AddMore from './AddMore';
 import EventItem from './EventItem';
 import SelectedArea from './SelectedArea';
@@ -496,8 +496,10 @@ class ResourceEvents extends PureComponent {
               durationStart = localeDayjs(new Date(startDate)).add(config.dayStartFrom, 'hours');
               durationEnd = localeDayjs(endDate).add(config.dayStopTo + 1, 'hours');
             }
-            const eventStart = localeDayjs(evt.eventItem.start);
-            const eventEnd = localeDayjs(evt.eventItem.end);
+            // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
+            const eventStart = normalizeEventStart(evt.eventItem.start);
+            // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
+            const eventEnd = normalizeEventEnd(evt.eventItem.end);
             const isStart = eventStart >= durationStart;
             const isEnd = eventEnd <= durationEnd;
             let left = index * cellWidth + (index > 0 ? 2 : 3);

--- a/src/components/ResourceEvents.jsx
+++ b/src/components/ResourceEvents.jsx
@@ -496,9 +496,7 @@ class ResourceEvents extends PureComponent {
               durationStart = localeDayjs(new Date(startDate)).add(config.dayStartFrom, 'hours');
               durationEnd = localeDayjs(endDate).add(config.dayStopTo + 1, 'hours');
             }
-            // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
             const eventStart = normalizeEventStart(evt.eventItem.start);
-            // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
             const eventEnd = normalizeEventEnd(evt.eventItem.end);
             const isStart = eventStart >= durationStart;
             const isEnd = eventEnd <= durationEnd;

--- a/src/components/SchedulerData.js
+++ b/src/components/SchedulerData.js
@@ -774,9 +774,7 @@ export default class SchedulerData {
             : this.localeDayjs(new Date(time)).add(oldEnd.diff(oldStart), 'ms').format(DATETIME_FORMAT),
         };
 
-        // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
         const eventStart = normalizeEventStart(newEvent.start);
-        // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
         const eventEnd = normalizeEventEnd(newEvent.end);
         if (
           this.isEventInTimeWindow(eventStart, eventEnd, windowStart, windowEnd) &&
@@ -1147,9 +1145,7 @@ export default class SchedulerData {
       return diff < 0 ? 0 : diff;
     };
 
-    // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
     const eventStart = normalizeEventStart(startTime).toDate();
-    // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
     const eventEnd = normalizeEventEnd(endTime).toDate();
     let span = 0;
     const windowStart = new Date(this.startDate);
@@ -1325,9 +1321,7 @@ export default class SchedulerData {
         if (resourceEventsList.length > 0) {
           const resourceEvents = resourceEventsList[0];
           const span = this._getSpan(item.start, item.end, this.headers);
-          // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
           const eventStart = normalizeEventStart(item.start).toDate();
-          // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
           const eventEnd = normalizeEventEnd(item.end).toDate();
           let pos = -1;
 

--- a/src/components/SchedulerData.js
+++ b/src/components/SchedulerData.js
@@ -8,6 +8,7 @@ import { CellUnit, DATE_FORMAT, DATETIME_FORMAT, ViewType } from '../config/defa
 import { getDefaultLabels, getLabel } from '../config/i18n';
 import config from '../config/scheduler';
 import behaviors from '../helper/behaviors';
+import { normalizeEventEnd, normalizeEventStart } from '../helper/utility';
 
 export default class SchedulerData {
   constructor(
@@ -773,8 +774,10 @@ export default class SchedulerData {
             : this.localeDayjs(new Date(time)).add(oldEnd.diff(oldStart), 'ms').format(DATETIME_FORMAT),
         };
 
-        const eventStart = this.localeDayjs(newEvent.start);
-        const eventEnd = this.localeDayjs(newEvent.end);
+        // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
+        const eventStart = normalizeEventStart(newEvent.start);
+        // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
+        const eventEnd = normalizeEventEnd(newEvent.end);
         if (
           this.isEventInTimeWindow(eventStart, eventEnd, windowStart, windowEnd) &&
           (!oldDtstart || eventStart >= oldDtstart)
@@ -1144,8 +1147,10 @@ export default class SchedulerData {
       return diff < 0 ? 0 : diff;
     };
 
-    const eventStart = new Date(startTime);
-    const eventEnd = new Date(endTime);
+    // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
+    const eventStart = normalizeEventStart(startTime).toDate();
+    // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
+    const eventEnd = normalizeEventEnd(endTime).toDate();
     let span = 0;
     const windowStart = new Date(this.startDate);
     const windowEnd = new Date(this.endDate);
@@ -1320,8 +1325,10 @@ export default class SchedulerData {
         if (resourceEventsList.length > 0) {
           const resourceEvents = resourceEventsList[0];
           const span = this._getSpan(item.start, item.end, this.headers);
-          const eventStart = new Date(item.start);
-          const eventEnd = new Date(item.end);
+          // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
+          const eventStart = normalizeEventStart(item.start).toDate();
+          // normalizeEventEnd handles date-only strings (YYYY-MM-DD) to prevent UTC midnight timezone shift (issue #233)
+          const eventEnd = normalizeEventEnd(item.end).toDate();
           let pos = -1;
 
           resourceEvents.headerItems.forEach((header, index) => {

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -559,7 +559,11 @@ function Scheduler(props) {
     const resourceTableWidth = schedulerData.getResourceTableWidth();
     const schedulerContainerWidth = width - (config.resourceViewEnabled ? resourceTableWidth : 0);
 
-    const contentHeight = config.schedulerContentHeight;
+    const configuredContentHeight = config.schedulerContentHeight;
+    const contentHeight =
+      !config.responsiveByParent && configuredContentHeight === '100%'
+        ? schedulerData.getSchedulerContentDesiredHeight()
+        : configuredContentHeight;
     const resourcePaddingBottom = resourceScrollbarHeight === 0 ? contentScrollbarHeight : 0;
     const contentPaddingBottom = contentScrollbarHeight === 0 ? resourceScrollbarHeight : 0;
 
@@ -624,6 +628,9 @@ function Scheduler(props) {
 
     const schedulerViewStyle = {
       width: schedulerContainerWidth,
+    };
+
+    const schedulerViewColumnStyle = {
       verticalAlign: 'top',
     };
 
@@ -688,7 +695,7 @@ function Scheduler(props) {
             </section>
           </div>
         </td>
-        <td>
+        <td style={schedulerViewColumnStyle}>
           <div className="scheduler-view" style={schedulerViewStyle}>
             <div style={schedulerHeadWrapperStyle}>
               <section

--- a/src/helper/utility.js
+++ b/src/helper/utility.js
@@ -29,7 +29,7 @@ export function getNextNumericEventId(events) {
  * Returns true if the string is a date-only value (YYYY-MM-DD) with no time component.
  */
 export function isDateOnly(dateStr) {
-  return /^\d{4}-\d{2}-\d{2}$/.test(dateStr);
+  return typeof dateStr === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(dateStr);
 }
 
 /**

--- a/src/helper/utility.js
+++ b/src/helper/utility.js
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 export function getPos(element) {
   let x = 0;
   let y = 0;
@@ -21,4 +23,34 @@ export function getPos(element) {
 export function getNextNumericEventId(events) {
   const numericIds = events.map(event => event.id).filter(id => typeof id === 'number' && Number.isFinite(id));
   return Math.max(...numericIds, 0) + 1;
+}
+
+/**
+ * Returns true if the string is a date-only value (YYYY-MM-DD) with no time component.
+ */
+export function isDateOnly(dateStr) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(dateStr);
+}
+
+/**
+ * Normalizes an event start date string to a dayjs object.
+ * Date-only strings are treated as start-of-day.
+ */
+export function normalizeEventStart(dateStr) {
+  if (isDateOnly(dateStr)) {
+    return dayjs(dateStr).startOf('day');
+  }
+  return dayjs(dateStr);
+}
+
+/**
+ * Normalizes an event end date string to a dayjs object.
+ * Date-only strings are treated as end-of-day to avoid UTC midnight timezone shifting
+ * causing off-by-one errors in day-cell span calculations (particularly in Month view).
+ */
+export function normalizeEventEnd(dateStr) {
+  if (isDateOnly(dateStr)) {
+    return dayjs(dateStr).endOf('day');
+  }
+  return dayjs(dateStr);
 }

--- a/src/sample-data/sample1.js
+++ b/src/sample-data/sample1.js
@@ -128,7 +128,13 @@ const DemoData = {
       title: 'SAMPLE TASK (DATE-ONLY FORMAT)',
     },
     {
-      id: 1,
+    {
+      id: 16,
+      start: '2022-12-12',
+      end: '2022-12-14',
+      resourceId: 'r3',
+      title: 'SAMPLE TASK (DATE-ONLY FORMAT)',
+    },
       start: '2022-12-12',
       end: '2022-12-14',
       resourceId: 'r3',

--- a/src/sample-data/sample1.js
+++ b/src/sample-data/sample1.js
@@ -119,12 +119,13 @@ const DemoData = {
       end: '2022-12-27 23:30:00',
       resourceId: 'r1',
       title: 'R1 has many tasks 6',
-    },{
+    },
+    {
       id: 15,
-      start: '2022-12-23',
-      end: '2022-12-27',
-      resourceId: 'r1',
-      title: 'R1 has many tasks 7',
+      start: '2022-12-06',
+      end: '2022-12-09',
+      resourceId: 'r3',
+      title: 'SAMPLE TASK (DATE-ONLY FORMAT)',
     },
   ],
   eventsForTaskView: [

--- a/src/sample-data/sample1.js
+++ b/src/sample-data/sample1.js
@@ -124,7 +124,7 @@ const DemoData = {
       start: '2022-12-23',
       end: '2022-12-27',
       resourceId: 'r1',
-      title: 'R1 has many tasks 6',
+      title: 'R1 has many tasks 7',
     },
   ],
   eventsForTaskView: [

--- a/src/sample-data/sample1.js
+++ b/src/sample-data/sample1.js
@@ -128,13 +128,7 @@ const DemoData = {
       title: 'SAMPLE TASK (DATE-ONLY FORMAT)',
     },
     {
-    {
       id: 16,
-      start: '2022-12-12',
-      end: '2022-12-14',
-      resourceId: 'r3',
-      title: 'SAMPLE TASK (DATE-ONLY FORMAT)',
-    },
       start: '2022-12-12',
       end: '2022-12-14',
       resourceId: 'r3',

--- a/src/sample-data/sample1.js
+++ b/src/sample-data/sample1.js
@@ -119,6 +119,12 @@ const DemoData = {
       end: '2022-12-27 23:30:00',
       resourceId: 'r1',
       title: 'R1 has many tasks 6',
+    },{
+      id: 15,
+      start: '2022-12-23',
+      end: '2022-12-27',
+      resourceId: 'r1',
+      title: 'R1 has many tasks 6',
     },
   ],
   eventsForTaskView: [

--- a/src/sample-data/sample1.js
+++ b/src/sample-data/sample1.js
@@ -127,6 +127,13 @@ const DemoData = {
       resourceId: 'r3',
       title: 'SAMPLE TASK (DATE-ONLY FORMAT)',
     },
+    {
+      id: 1,
+      start: '2022-12-12',
+      end: '2022-12-14',
+      resourceId: 'r3',
+      title: 'SAMPLE TASK (DATE-ONLY FORMAT)',
+    },
   ],
   eventsForTaskView: [
     {


### PR DESCRIPTION
## Summary

Fixes #233

Date-only event strings (`YYYY-MM-DD`) rendered one day shorter than expected
in Month view. Week and Two-Week views were unaffected.

## Root Cause

When dayjs parses a date-only string (no time component), it defaults to
midnight UTC. In timezones ahead of UTC (e.g. UTC+5:30), this shifts the
date back by several hours — landing on the previous calendar day. The
month view's integer day-cell span calculation then comes up one short.

Datetime strings (`YYYY-MM-DD HH:mm:ss`) were unaffected because they are
parsed in local time.

## Fix

Added `normalizeEventStart` and `normalizeEventEnd` utility functions that
detect date-only strings and anchor them to start-of-day / end-of-day in
local time before any span or overlap calculations. Datetime strings pass
through unchanged, so existing behaviour is fully preserved.

## Testing

- Manually verified in Month and Week views
- All existing tests pass

## Screenshots

For a Sample Event using date-only format:
```
{
  id: 15,
  start: '2022-12-06',
  end: '2022-12-09',
  resourceId: 'r3',
  title: 'SAMPLE TASK (DATE-ONLY FORMAT)',
},
```

-Before:
<img width="1871" height="952" alt="image" src="https://github.com/user-attachments/assets/5c6fd9c2-3f63-4b5c-b8d6-888dda7adcb5" />
For date-only format, an event used to render one day shorter.

-After:
<img width="1870" height="953" alt="image" src="https://github.com/user-attachments/assets/ca7aa1bf-24c5-4253-a0c9-b607673bf5cb" />
Event covers full span.


## Additional Fix

Fixed a layout inconsistency where the scheduler content area could render taller than the actual resource rows when `schedulerContentHeight` was set to `100%`. Non-responsive views now size the content area to the rendered row height, removing the extra blank row and keeping the resource column aligned with the event grid.

Before:
<img width="1245" height="637" alt="Screenshot 2026-06-06 135418" src="https://github.com/user-attachments/assets/8501ef09-e8f8-4020-ad70-62084d84855b" />
<img width="1141" height="509" alt="Screenshot 2026-06-06 135430" src="https://github.com/user-attachments/assets/764528ba-eea7-4d5d-9f7e-f8b4dcbb24df" />

After:
<img width="1617" height="577" alt="image" src="https://github.com/user-attachments/assets/947bdf85-dc3a-4643-ae4b-dadc5f1e66ab" />
<img width="1601" height="423" alt="image" src="https://github.com/user-attachments/assets/22d54416-dc54-4602-9e95-0bd3350e9bef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for date-only event format (YYYY-MM-DD); date-only events span the full calendar day across all views.

* **Documentation**
  * README updated with an "Event Date Formats" section describing supported formats and behavior.

* **Improvements**
  * More consistent event boundary handling and responsive content sizing; sample demo data includes date-only events for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->